### PR TITLE
Fix tests with respect to manopt update

### DIFF
--- a/src/natural_manifolds/normal.jl
+++ b/src/natural_manifolds/normal.jl
@@ -42,3 +42,27 @@ function partition_point(
     k = first(dims)
     return ArrayPartition(view(p, 1:k), reshape(view(p, (k + 1):(k + k^2)), (k, k)))
 end
+
+"""
+    get_natural_manifold_base(::Type{MvNormalMeanScalePrecision}, dims::Tuple{Int}, conditioner = nothing)
+
+Get the natural manifold base for the `MvNormalMeanScalePrecision` distribution.
+"""
+function get_natural_manifold_base(
+    ::Type{MvNormalMeanScalePrecision}, dims::Tuple{Int}, conditioner=nothing
+)
+    k = first(dims)
+    return ProductManifold(Euclidean(k), ShiftedNegativeNumbers(static(0)))
+end
+
+"""
+    partition_point(::Type{MvNormalMeanCovariance}, dims::Tuple{Int}, p, conditioner = nothing)
+
+Converts the `point` to a compatible representation for the natural manifold of type `MvNormalMeanCovariance`.
+"""
+function partition_point(
+    ::Type{MvNormalMeanScalePrecision}, dims::Tuple{Int}, p, conditioner=nothing
+)
+    k = first(dims)
+    return ArrayPartition(view(p, 1:k), view(p, k+1:k+1))
+end

--- a/test/natural_manifolds/normal_tests.jl
+++ b/test/natural_manifolds/normal_tests.jl
@@ -17,3 +17,14 @@ end
         return MvNormalMeanCovariance(m, C)
     end
 end
+
+@testitem "Check `MvNormalMeanScalePrecision` natural manifold" begin
+    include("natural_manifolds_setuptests.jl")
+
+    test_natural_manifold() do rng
+        k = rand(rng, 1:10)
+        m = randn(rng, k)
+        γ = rand(rng)^2 + 1
+        return MvNormalMeanScalePrecision(m, C)
+    end
+end

--- a/test/shifted_negative_numbers_tests.jl
+++ b/test/shifted_negative_numbers_tests.jl
@@ -159,7 +159,7 @@ end
         b in (10.0, 5.0),
         c in (1.0, 10.0, -1.0),
         eps in (1e-4, 1e-5, 1e-8, 1e-10),
-        stepsize in (ConstantStepsize(0.1), ConstantStepsize(0.01), ConstantStepsize(0.001))
+        stepsize in (ConstantLength(0.1), ConstantLength(0.01), ConstantLength(0.001))
 
         expected_q = -b / 2a
         expected_minimum = c - b^2 / (4a)
@@ -232,11 +232,11 @@ end
         obj = ManifoldGradientObjective(missing, grad_f!; evaluation=InplaceEvaluation())
         dmp = DefaultManoptProblem(M, obj)
         s = GradientDescentState(
-            M,
-            q;
+            M;
+            p = q,
             stopping_criterion=StopWhenGradientNormLessNonAllocating(1e-8),
             stepsize=ConstantStepsizeNonAllocating(0.1),
-            direction=IdentityUpdateRule(),
+            direction=Manopt.IdentityUpdateRule(),
             retraction_method=default_retraction_method(M, typeof(q)),
             X=zero_vector(M, q),
         )

--- a/test/shifted_positive_numbers_tests.jl
+++ b/test/shifted_positive_numbers_tests.jl
@@ -159,7 +159,7 @@ end
         b in (-10.0, -5.0),
         c in (1.0, 10.0, -1.0),
         eps in (1e-4, 1e-5, 1e-8, 1e-10),
-        stepsize in (ConstantStepsize(0.1), ConstantStepsize(0.01), ConstantStepsize(0.001))
+        stepsize in (ConstantLength(0.1), ConstantLength(0.01), ConstantLength(0.001))
 
         expected_q = -b / 2a
         expected_minimum = c - b^2 / (4a)
@@ -231,11 +231,11 @@ end
         obj = ManifoldGradientObjective(missing, grad_f!; evaluation=InplaceEvaluation())
         dmp = DefaultManoptProblem(M, obj)
         s = GradientDescentState(
-            M,
-            q;
+            M;
+            p = q,
             stopping_criterion=StopWhenGradientNormLessNonAllocating(1e-8),
             stepsize=ConstantStepsizeNonAllocating(0.1),
-            direction=IdentityUpdateRule(),
+            direction=Manopt.IdentityUpdateRule(),
             retraction_method=default_retraction_method(M, typeof(q)),
             X=zero_vector(M, q),
         )


### PR DESCRIPTION
This PR fixes the tests with respect to a breaking Manopt update.

@bvdmitri @wouterwln We do not have a compat entry for our test dependencies, so once a test dependency has an update, our tests can break. I wonder why we don't have them, because as I understand, Julia respects compat even on packages that are not dependencies.