### PR TITLE
#49 Add better errors for get_natural_manifold_base and ...

### DIFF
--- a/src/natural_manifolds/binomial.jl
+++ b/src/natural_manifolds/binomial.jl
@@ -4,7 +4,27 @@
 Get the natural manifold base for the `Binomial` distribution.
 """
 function get_natural_manifold_base(::Type{Binomial}, ::Tuple{}, conditioner=nothing)
-    @assert conditioner >= 0 "Conditioner $(conditioner) should be positive"
+    if conditioner === nothing
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{Binomial},..., conditioner): `conditioner` was left as `nothing`. Please provide a non-negative numeric conditioner (e.g. 0.0 or 1.0).",
+            ),
+        )
+    end
+    if !(conditioner isa Number)
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{Binomial},..., conditioner): `conditioner` must be a Number, got $(typeof(conditioner)).",
+            ),
+        )
+    end
+    if conditioner < 0
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{Binomial},..., conditioner): `conditioner` must be >= 0, got $(conditioner).",
+            ),
+        )
+    end
     return Euclidean(1)
 end
 
@@ -14,7 +34,27 @@ end
 Converts the `point` to a compatible representation for the natural manifold of type `Binomial`.
 """
 function partition_point(::Type{Binomial}, ::Tuple{}, p, conditioner=nothing)
-    @assert conditioner >= 0 "Conditioner $(conditioner) should be positive"
+    if conditioner === nothing
+        throw(
+            ArgumentError(
+                "partition_point(::Type{Binomial},..., conditioner): `conditioner` was left as `nothing`. Please provide a non-negative numeric conditioner.",
+            ),
+        )
+    end
+    if !(conditioner isa Number)
+        throw(
+            ArgumentError(
+                "partition_point(::Type{Binomial},..., conditioner): `conditioner` must be a Number, got $(typeof(conditioner)).",
+            ),
+        )
+    end
+    if conditioner < 0
+        throw(
+            ArgumentError(
+                "partition_point(::Type{Binomial},..., conditioner): `conditioner` must be >= 0, got $(conditioner).",
+            ),
+        )
+    end
     return p
 end
 

--- a/src/natural_manifolds/categorical.jl
+++ b/src/natural_manifolds/categorical.jl
@@ -5,6 +5,27 @@
 Get the natural manifold base for the `Categorical` distribution.
 """
 function get_natural_manifold_base(::Type{Categorical}, ::Tuple{}, conditioner=nothing)
+    if conditioner === nothing
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{Categorical},..., conditioner): `conditioner` was left as `nothing`. Please provide a non-negative numeric conditioner (e.g. 0.0 or 1.0).",
+            ),
+        )
+    end
+    if !(conditioner isa Number)
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{Categorical},..., conditioner): `conditioner` must be a Number, got $(typeof(conditioner)).",
+            ),
+        )
+    end
+    if conditioner < 1
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{Categorical},..., conditioner): `conditioner` must be >= 1, got $(conditioner).",
+            ),
+        )
+    end
     return ProductManifold(Euclidean(conditioner - 1), SinglePointManifold([0.0]))
 end
 
@@ -14,6 +35,27 @@ end
 Converts the `point` to a compatible representation for the natural manifold of type `Categorical`.
 """
 function partition_point(::Type{Categorical}, ::Tuple{}, p, conditioner=nothing)
+    if conditioner === nothing
+        throw(
+            ArgumentError(
+                "partition_point(::Type{Categorical},..., conditioner): `conditioner` was left as `nothing`. Please provide a non-negative numeric conditioner.",
+            ),
+        )
+    end
+    if !(conditioner isa Number)
+        throw(
+            ArgumentError(
+                "partition_point(::Type{Categorical},..., conditioner): `conditioner` must be a Number, got $(typeof(conditioner)).",
+            ),
+        )
+    end
+    if conditioner < 1
+        throw(
+            ArgumentError(
+                "partition_point(::Type{Categorical},..., conditioner): `conditioner` must be >= 1, got $(conditioner).",
+            ),
+        )
+    end
     return ArrayPartition(view(p, 1:(conditioner - 1)), view(p, conditioner:conditioner))
 end
 

--- a/src/natural_manifolds/negative_binomial.jl
+++ b/src/natural_manifolds/negative_binomial.jl
@@ -4,7 +4,27 @@
 Get the natural manifold base for the `NegativeBinomial` distribution.
 """
 function get_natural_manifold_base(::Type{NegativeBinomial}, ::Tuple{}, conditioner=nothing)
-    @assert conditioner >= 0 "Conditioner should be non-negative"
+    if conditioner === nothing
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{NegativeBinomial},..., conditioner): `conditioner` was left as `nothing`. Please provide a non-negative numeric conditioner (e.g. 0.0 or 1.0).",
+            ),
+        )
+    end
+    if !(conditioner isa Number)
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{NegativeBinomial},..., conditioner): `conditioner` must be a Number, got $(typeof(conditioner)).",
+            ),
+        )
+    end
+    if conditioner < 0
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{NegativeBinomial},..., conditioner): `conditioner` must be >= 0, got $(conditioner).",
+            ),
+        )
+    end
     return Euclidean(1)
 end
 
@@ -14,7 +34,27 @@ end
 Converts the `point` to a compatible representation for the natural manifold of type `NegativeBinomial`.
 """
 function partition_point(::Type{NegativeBinomial}, ::Tuple{}, p, conditioner=nothing)
-    @assert conditioner >= 0 "Conditioner should be non-negative"
+    if conditioner === nothing
+        throw(
+            ArgumentError(
+                "partition_point(::Type{NegativeBinomial},..., conditioner): `conditioner` was left as `nothing`. Please provide a non-negative numeric conditioner.",
+            ),
+        )
+    end
+    if !(conditioner isa Number)
+        throw(
+            ArgumentError(
+                "partition_point(::Type{NegativeBinomial},..., conditioner): `conditioner` must be a Number, got $(typeof(conditioner)).",
+            ),
+        )
+    end
+    if conditioner < 0
+        throw(
+            ArgumentError(
+                "partition_point(::Type{NegativeBinomial},..., conditioner): `conditioner` must be >= 0, got $(conditioner).",
+            ),
+        )
+    end
     return p
 end
 

--- a/src/natural_manifolds/weibull.jl
+++ b/src/natural_manifolds/weibull.jl
@@ -4,7 +4,27 @@
 Get the natural manifold base for the `Weibull` distribution.
 """
 function get_natural_manifold_base(::Type{Weibull}, ::Tuple{}, conditioner=nothing)
-    @assert conditioner > 0 "Conditioner $(conditioner) should be positive"
+    if conditioner === nothing
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{Weibull},..., conditioner): `conditioner` was left as `nothing`. Please provide a non-negative numeric conditioner (e.g. 0.0 or 1.0).",
+            ),
+        )
+    end
+    if !(conditioner isa Number)
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{Weibull},..., conditioner): `conditioner` must be a Number, got $(typeof(conditioner)).",
+            ),
+        )
+    end
+    if conditioner < 0
+        throw(
+            ArgumentError(
+                "get_natural_manifold_base(::Type{Weibull},..., conditioner): `conditioner` must be >= 0, got $(conditioner).",
+            ),
+        )
+    end
     return ProductManifold(PositiveVectors(1))
 end
 
@@ -14,7 +34,27 @@ end
 Converts the `point` to a compatible representation for the natural manifold of type `Weibull`.
 """
 function partition_point(::Type{Weibull}, ::Tuple{}, p, conditioner=nothing)
-    @assert conditioner > 0 "Conditioner $(conditioner) should be positive"
+    if conditioner === nothing
+        throw(
+            ArgumentError(
+                "partition_point(::Type{Weibull},..., conditioner): `conditioner` was left as `nothing`. Please provide a non-negative numeric conditioner.",
+            ),
+        )
+    end
+    if !(conditioner isa Number)
+        throw(
+            ArgumentError(
+                "partition_point(::Type{Weibull},..., conditioner): `conditioner` must be a Number, got $(typeof(conditioner)).",
+            ),
+        )
+    end
+    if conditioner < 0
+        throw(
+            ArgumentError(
+                "partition_point(::Type{Weibull},..., conditioner): `conditioner` must be >= 0, got $(conditioner).",
+            ),
+        )
+    end
     return ArrayPartition(-p)
 end
 

--- a/test/natural_manifolds/binomial_tests.jl
+++ b/test/natural_manifolds/binomial_tests.jl
@@ -14,3 +14,12 @@ end
         return dist
     end
 end
+
+@testitem "Conditioner errors" begin
+    import ExponentialFamily: Binomial
+    import ExponentialFamilyManifolds: get_natural_manifold_base, partition_point
+    @test_throws ArgumentError get_natural_manifold_base(Binomial, ())
+    @test_throws ArgumentError get_natural_manifold_base(Binomial, (), -1.0)
+    @test_throws ArgumentError partition_point(Binomial, (), 0.5)
+    @test_throws ArgumentError partition_point(Binomial, (), 0.5, -1.0)
+end

--- a/test/natural_manifolds/categorical_tests.jl
+++ b/test/natural_manifolds/categorical_tests.jl
@@ -64,3 +64,12 @@ end
         return Categorical(rand(rng, 3))
     end
 end
+
+@testitem "Conditioner errors" begin
+    import ExponentialFamily: Categorical
+    import ExponentialFamilyManifolds: get_natural_manifold_base, partition_point
+    @test_throws ArgumentError get_natural_manifold_base(Categorical, ())
+    @test_throws ArgumentError get_natural_manifold_base(Categorical, (), 0.0)
+    @test_throws ArgumentError partition_point(Categorical, (), 0.5)
+    @test_throws ArgumentError partition_point(Categorical, (), 0.5, 0.0)
+end

--- a/test/natural_manifolds/negative_binomial_tests.jl
+++ b/test/natural_manifolds/negative_binomial_tests.jl
@@ -12,3 +12,12 @@ end
         return NegativeBinomial(rand(rng), rand(rng, 0.00001:0.01:1))
     end
 end
+
+@testitem "Conditioner errors" begin
+    import ExponentialFamily: NegativeBinomial
+    import ExponentialFamilyManifolds: get_natural_manifold_base, partition_point
+    @test_throws ArgumentError get_natural_manifold_base(NegativeBinomial, ())
+    @test_throws ArgumentError get_natural_manifold_base(NegativeBinomial, (), -1.0)
+    @test_throws ArgumentError partition_point(NegativeBinomial, (), 0.5)
+    @test_throws ArgumentError partition_point(NegativeBinomial, (), 0.5, -1.0)
+end

--- a/test/natural_manifolds/weibull_tests.jl
+++ b/test/natural_manifolds/weibull_tests.jl
@@ -12,3 +12,12 @@ end
         return Weibull(rand(rng), rand(rng))
     end
 end
+
+@testitem "Conditioner errors" begin
+    import ExponentialFamily: Weibull
+    import ExponentialFamilyManifolds: get_natural_manifold_base, partition_point
+    @test_throws ArgumentError get_natural_manifold_base(Weibull, ())
+    @test_throws ArgumentError get_natural_manifold_base(Weibull, (), -1.0)
+    @test_throws ArgumentError partition_point(Weibull, (), 0.5)
+    @test_throws ArgumentError partition_point(Weibull, (), 0.5, -1.0)
+end


### PR DESCRIPTION
partition_point for Binomial, Categorical, NegativeBinomial, Weibull.

Resolves #49 

Actually we should check `conditioner` in a general way before `get_natural_manifold_base` or `partition_point` are being called for the individual distributions - should avoid repetitive code.
